### PR TITLE
chore: upgrade Go and golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16.5'
-    - run: go version
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.3'
+        go-version: '1.16.5'
     - run: go version
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.40
+        version: v1.41
 
     - run: go test -v ./... -race -covermode=atomic
 

--- a/pkg/buildspec/phase.go
+++ b/pkg/buildspec/phase.go
@@ -32,7 +32,7 @@ func (phase *Phase) Filter(param interface{}) (map[string]interface{}, error) {
 }
 
 func (phases *Phases) Filter(param interface{}) (map[string]interface{}, error) {
-	m := make(map[string]interface{}, 4)
+	m := make(map[string]interface{}, 4) //nolint:gomnd
 
 	install, err := phases.Install.Filter(param)
 	if err != nil {


### PR DESCRIPTION
* Go 1.16.3 => 1.16.5
* golangci-lint v1.40 => v1.41