### PR TITLE
feat: add utility functions

### DIFF
--- a/docs/expression.md
+++ b/docs/expression.md
@@ -20,6 +20,7 @@ The following parameters are passed to expressions.
 .getPRFiles | `func() []*github.CommitFile` | | get associated pull request files
 .getPRFileNames | `func() []string` | | get associated pull request file paths
 .getPRLabelNames | `func() []string` | | get associated pull request label names
+.util | `map[string]interface{}` | | [utility functions](#utility-functions)
 
 Please see [go-github's document](https://pkg.go.dev/github.com/google/go-github/v36/github) too.
 
@@ -58,3 +59,9 @@ This is the reason why the type of parameters like `getPRFileNames` is function.
 .FullName | string | `suzuki-shunsuke/test-lambuild` |
 .Owner | string | `suzuki-shunsuke` |
 .Name | string | `test-lambuild` |
+
+## Utility Functions
+
+name | type | example | description
+--- | --- | --- | ---
+value | `func(interface{}) interface{}` | `value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, panic occurs

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -64,4 +64,4 @@ This is the reason why the type of parameters like `getPRFileNames` is function.
 
 name | type | example | description
 --- | --- | --- | ---
-value | `func(interface{}) interface{}` | `value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, panic occurs
+value | `func(interface{}) interface{}` | `value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, the argument is returned

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -64,4 +64,4 @@ This is the reason why the type of parameters like `getPRFileNames` is function.
 
 name | type | example | description
 --- | --- | --- | ---
-value | `func(interface{}) interface{}` | `value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, the argument is returned
+value | `func(interface{}) interface{}` | `util.value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, the argument is returned

--- a/pkg/domain/expr_funcs.go
+++ b/pkg/domain/expr_funcs.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/google/go-github/v36/github"
 )
@@ -16,7 +17,18 @@ import (
 // > For example, if your function going to divide by zero 1/0 Expr will also work correctly as it will panic.
 
 func setExprFuncs(env map[string]interface{}) map[string]interface{} {
-	return env
+	m := make(map[string]interface{}, len(env)+1)
+	for k, v := range env {
+		m[k] = v
+	}
+	m["util"] = map[string]interface{}{
+		"value": Value,
+	}
+	return m
+}
+
+func Value(ptr interface{}) interface{} {
+	return reflect.ValueOf(ptr).Elem().Interface()
 }
 
 func (data *Data) GetCommit() *github.Commit {

--- a/pkg/domain/expr_funcs.go
+++ b/pkg/domain/expr_funcs.go
@@ -28,7 +28,11 @@ func setExprFuncs(env map[string]interface{}) map[string]interface{} {
 }
 
 func Value(ptr interface{}) interface{} {
-	return reflect.ValueOf(ptr).Elem().Interface()
+	v := reflect.ValueOf(ptr)
+	if v.Kind() != reflect.Ptr {
+		return ptr
+	}
+	return v.Elem().Interface()
 }
 
 func (data *Data) GetCommit() *github.Commit {


### PR DESCRIPTION
## Feature

* Add utility functions which can be used in `expr`'s expression

### Utility Functions

name | type | example | description
--- | --- | --- | ---
value | `func(interface{}) interface{}` | `util.value(event.Payload.PullRequest.Head.Ref)` | get a value from a pointer. If the argument isn't a pointer, panic occurs